### PR TITLE
chore: ESLint - react/require-default-props 룰 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
   "plugins": ["react", "@typescript-eslint", "prettier"],
   "rules": {
     "react/jsx-props-no-spreading": 0,
+    "react/require-default-props": 0,
     "react/function-component-definition": [
       2,
       { "namedComponents": "arrow-function" }


### PR DESCRIPTION
## What is this PR? :mag:

- ESLint - react/require-default-props 룰을 수정합니다.

## branch

- chore/#12 -> dev

## Changes :memo:

- TypeScript를 사용하고 있어 ESLint - react/require-default-props 를 사용하지 않도록 수정합니다.

#12 by @Jeremy-Kr 
