### PR TITLE
refactor(PostTitle, SideBar): border 삭제와 key값 추가

### DIFF
--- a/Components/Main/SideBar.tsx
+++ b/Components/Main/SideBar.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import check from "@/public/icons/check.svg";
 import Image from "next/image";
-import LargeCategory from "./LargeCategory";
 import { useRecoilState } from "recoil";
 import { largeCategoryState, subCategoryState } from "@/lib/recoil";
+import LargeCategory from "./LargeCategory";
 
 interface SubCategoryItemsType {
   [key: string]: string[];
@@ -56,7 +56,7 @@ const SideBar = () => {
       <SideBarHr />
       <CategoryContainer>
         {largeCategoryItems.map((item: string) => (
-          <>
+          <li key={item}>
             <LargeCategory
               item={item}
               selectedCategory={selectedCategory}
@@ -91,7 +91,7 @@ const SideBar = () => {
                   )
                 )}
             </SubCategoryItemsContainer>
-          </>
+          </li>
         ))}
       </CategoryContainer>
     </SideBarContainer>
@@ -118,7 +118,7 @@ const SideBarHr = styled.hr`
   margin: 1.5rem 0;
 `;
 
-const CategoryContainer = styled.div`
+const CategoryContainer = styled.ul`
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/Components/Post/PostTitle.tsx
+++ b/Components/Post/PostTitle.tsx
@@ -62,7 +62,6 @@ const TitleContainer = styled.div`
   flex-direction: column;
   padding: 3rem;
   gap: 1.375rem;
-  border: 1px solid black;
   position: relative;
   background-color: ${(props) => props.color};
 `;


### PR DESCRIPTION
- `Expectation Violation: Duplicate atom key "largeCategoryState"` 애러 해결 - key값을 추가하는 방법으로 해결
- title 컴포넌트 border 삭제

# 74

## What is this PR? :mag:

- PostTitle 컴포넌트를 감싸는 1px를 삭제합니다.
- SideBar 컴포넌트의 key값 지정 에러도 해결합니다.

## branch

- feat/TitleBorder -> dev

## Changes :memo:

- 

(#74 ) by @arch-spatula 
