### PR TITLE
fix: detailpage first rendering bug

### DIFF
--- a/Components/Detail/Comment.tsx
+++ b/Components/Detail/Comment.tsx
@@ -29,7 +29,7 @@ const Comment = () => {
   return (
     <CommentContainer>
       {currentUser && <CommentInput POST_ID={POST_ID} USER_ID={userId} />}
-      <CommentList POST_ID={POST_ID} />
+      {POST_ID && <CommentList POST_ID={POST_ID} />}
     </CommentContainer>
   );
 };

--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -96,7 +96,7 @@ const DetailPage: NextPage = () => {
           <DetailSide {...sideData} />
         </DetailContentsSide>
         <DetailContentsMain>
-          <Viewer content={content} />
+          {content && <Viewer content={content} />}{" "}
         </DetailContentsMain>
       </DetailContentsContainer>
       <RelatedProject />

--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -96,7 +96,7 @@ const DetailPage: NextPage = () => {
           <DetailSide {...sideData} />
         </DetailContentsSide>
         <DetailContentsMain>
-          {content && <Viewer content={content} />}{" "}
+          {content && <Viewer content={content} />}
         </DetailContentsMain>
       </DetailContentsContainer>
       <RelatedProject />


### PR DESCRIPTION
초기 진입 시 데이터 렌더링이 안되는 현상 #143

## What is this PR? :mag:

- detailpage 초기 랜더링 시 데이터를 못불러오는 버그입니다. 
- 옵셔널 체이닝으로 해결 했습니다. (다른 환경에서도 확인 필요할 듯, 제 컴퓨터에서는 정상 동작)
- viewer 말고도 댓글에서도 같은 원리로 같은 형상이 발견되어서 같이 해결 했습니다. 
- 정익님이랑 같은 이슈에 대한 PR이기 때문에 원만한 합의를 통해 둘 중 하나만 merge 하면 될 것 같습니다. 

## branch

- feat/fetailPage-bug -> dev

## Changes :memo:

- 덧붙이자면 
![image](https://user-images.githubusercontent.com/50473516/219881961-ee6d9810-98b0-4ba3-8b95-b3757bc9f7f7.png)
즉, 첫 랜더링시 query의 값이 undefined가 되고 그를 기반으로 get요청을 해서 데이터가 랜더링 되지 않는 현상입니다. 

- 리코일로 state를 관리하면 동작가능 할 것 같습니다. 하지만 제가 리코일로 리팩토링 시도했을 때는 새로고침시 state값이 초기화 현상으로 완성하지 못했습니다. 

(#144 ) by @yunjunhojj 
