### PR TITLE
fix: sidebar 랜더링시 위치이동 현상 제거

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -1,3 +1,7 @@
 body {
   font-family: "Noto Sans KR", sans-serif;
 }
+
+html {
+  overflow-y: scroll;
+}


### PR DESCRIPTION
## What is this PR? :mag:

- 메인페이지가 랜더링 되면서 사이드바가 이동하는 현상에 대한 pr입니다. 

## branch

- feat/sidebar-render-bug -> dev

## Changes :memo:

- 해당 사유를 scroll이 생기면서 scroll-bar의 위치만큼 이동하게 되는 현상입니다. 
- 글로벌 css에 "  overflow-y: scroll; " 를 추가했습니다. 글로벌에 넣은 이유는 잘 안보일 수도 있지만, 다른 scroll이 생기는 (ex. post) 부분에서도 같은 현상이 발생하는 것으로 보였습니다. 

#223  by @yunjunhojj 
