### PR TITLE
fix: 최초 진입 시 본인 프로필 가져오기

### DIFF
--- a/Components/CreatePost/Post/WithPeople.tsx
+++ b/Components/CreatePost/Post/WithPeople.tsx
@@ -20,6 +20,7 @@ const WithPeople = () => {
   // github 추가해야 함
   const {
     profileData: { user_name: userName, field: userField, github: userGithub },
+    isLoading,
   } = useUserProfile();
 
   useEffect(() => {
@@ -30,7 +31,7 @@ const WithPeople = () => {
     setPeople([
       { name: userName, field: userField.join(), github: userGithub },
     ]);
-  }, []);
+  }, [userName]);
 
   const addPerson = () => {
     if (people.length === 0) {
@@ -58,6 +59,9 @@ const WithPeople = () => {
     setPeople(newPeople);
   };
 
+  // TODO: 로딩 스피너 변경
+  if (isLoading) return null;
+
   return (
     <WithPeopleContainer>
       {people.map((person, idx) => (
@@ -81,20 +85,6 @@ const WithPeople = () => {
             />
             <HelperTextBox text={membersVaildate} />
           </HelperTextContainer>
-          {/* <CategoryPicker onClick={handleShowCategory}>
-            {largeCategory && subCategory ? (
-              <span>{subCategory}</span>
-            ) : (
-              <span>카테고리를 선택해주세요.</span>
-            )}
-            <DropdownImage
-              src={arrow_down}
-              alt="category selete icon"
-              width={16}
-              height={16}
-            />
-            {categoryVisible && <FieldDropDown />}
-          </CategoryPicker> */}
           <HelperTextContainer>
             <InputStyle
               placeholder="https://github.com/user"

--- a/hooks/query/useUserProfile.ts
+++ b/hooks/query/useUserProfile.ts
@@ -14,7 +14,7 @@ const useUserProfile = () => {
   const queryClient = useQueryClient();
 
   // get
-  const { data } = useQuery([USER_PROFILE], getUserProfile, {});
+  const { data, isLoading } = useQuery([USER_PROFILE], getUserProfile, {});
 
   // null이면 갱신
   const profileData: UserProfileType = {
@@ -61,7 +61,7 @@ const useUserProfile = () => {
     },
   });
 
-  return { profileData, updateProfileData };
+  return { profileData, updateProfileData, isLoading };
 };
 
 export default useUserProfile;


### PR DESCRIPTION
# TODO
- [ ] 로딩 스피너 추가
- [ ] 프로젝트 기간 width 디자인에 맞게 변경
- [ ] 깃허브주소, 배포주소 padding 추가 및 취소버튼 추가
- [ ] 함께한 사람들 1번 이름 disabled처리, 각각 인풋 width 디자인에 맞게 처리, 취소버튼 추가

## What is this PR? :mag:

- 최초 진입 시 본인 프로필 가져오기

## branch

- fix/post-page-first-render -> dev

## Changes :memo:

- post page에 최초 진입 시 본인의 프로필을 가져옵니다.

#271  by @Jeremy-Kr 
