### PR TITLE
fix(Post): 수정 후 postId가 바뀌는 현상

### DIFF
--- a/Components/CreatePost/Post/Post.tsx
+++ b/Components/CreatePost/Post/Post.tsx
@@ -92,7 +92,9 @@ const Post: NextPage = () => {
   const setContentValidate = useSetRecoilState(postContentValidate);
 
   const newPostRow = {
-    id: isPostId,
+    id: (router.asPath === "/create-post"
+      ? isPostId
+      : router.query.id) as string,
     title,
     sub_title: subTitle,
     title_background_image: titleBackgroundImage,
@@ -116,8 +118,14 @@ const Post: NextPage = () => {
         setUserId(data.session?.user.id);
       }
     };
-    setErrorMessage("");
 
+    if (router.asPath === "/create-post") {
+      setIsPostId(uuidv4());
+    } else {
+      setIsPostId(router.query.id as string);
+    }
+
+    setErrorMessage("");
     LoginState();
   }, []);
 


### PR DESCRIPTION
## What is this PR? :mag:

- edit-page에서 수정 후 게시가 된다면 기존 post ID(uuid)가 변경되던 현상 해결

## branch

- fix/notification-router-error -> dev

## Changes :memo:

- edit page 에서는 기존 query.id 로 해당 포스트 아이디를 찾아 다시 uuid 가 리셋되지 않도록 변경

(#308 #311) by @hyoloui


## AS-IS
![Mar-07-2023 01-53-53_edit](https://user-images.githubusercontent.com/115724947/223179710-500613ee-2ee1-444b-ba6b-62581ab8edcf.gif)
![Mar-07-2023 01-55-26_notification](https://user-images.githubusercontent.com/115724947/223179850-9ae22c9c-0379-45dc-a706-c33d27c006fd.gif)

---

## TO-BE
![Mar-07-2023 02-07-49_edit_tobe](https://user-images.githubusercontent.com/115724947/223181243-a8a7ea8f-1053-49a2-a5dc-e80564d652c7.gif)
![Mar-07-2023 02-08-21_notification_tobe](https://user-images.githubusercontent.com/115724947/223181268-3856bb7a-19b8-4691-8173-65b75ec70da9.gif)
