### PR TITLE
fix: 이미지 뒤로 텍스트가 넘어가는 현상 픽스

### DIFF
--- a/Components/Detail/DetailTitle.tsx
+++ b/Components/Detail/DetailTitle.tsx
@@ -59,6 +59,7 @@ const DetailTitleBackgroundImage = styled(Image)`
 const DetailTitleHeader = styled.p`
   ${({ theme }) => theme.fonts.subtitle18En};
   color: ${(props) => props.theme.colors.gray3};
+  z-index: 1;
 `;
 
 const DetailTitleText = styled.div`
@@ -73,6 +74,7 @@ const DetailTitleText = styled.div`
     ${({ theme }) => theme.fonts.subtitle18};
     color: ${(props) => props.theme.colors.gray3};
   }
+  z-index: 1;
 `;
 
 export default DetailTitle;


### PR DESCRIPTION
## AS-IS
<img width="1382" alt="image" src="https://user-images.githubusercontent.com/110771206/223429690-6de8fcd2-1b3a-40ae-8c55-5ef6987c090a.png">

## TO-BE
<img width="1381" alt="image" src="https://user-images.githubusercontent.com/110771206/223429849-4fc83a56-9c7a-4c5f-9800-7ca56b3b9023.png">
