### PR TITLE
fix: 깃허브 주소 유효성 검사

### DIFF
--- a/Components/CreatePost/Post/Post.tsx
+++ b/Components/CreatePost/Post/Post.tsx
@@ -163,7 +163,7 @@ const Post: NextPage = () => {
       if (members[index].field === "") {
         newMembersValidate[index].field = "필수 입력 항목입니다.";
       }
-      if (!checkUrl(members[index].github)) {
+      if (!checkUrl(members[index].github, true)) {
         newMembersValidate[index].github = "깃허브 주소 형식에 맞지 않습니다.";
       }
     }
@@ -209,7 +209,7 @@ const Post: NextPage = () => {
       setErrorMessage("프로젝트 제목 또는 소제목을 입력해주세요");
     }
 
-    if (githubUrl && !checkUrl(githubUrl)) {
+    if (githubUrl && !checkUrl(githubUrl, true)) {
       setGithubUrlValidate("깃허브 주소 형식에 맞지 않습니다.");
     }
 

--- a/utils/commons/checkUrl.ts
+++ b/utils/commons/checkUrl.ts
@@ -1,6 +1,8 @@
 // url 유효성 검사 함수
-const checkUrl = (url: string): boolean => {
-  const expression = /^(ftp|http|https):\/\/github.com\/[^ "]+$/;
+const checkUrl = (url: string, isGithub = false): boolean => {
+  const expression = isGithub
+    ? /^https:\/\/github.com\/[^ "]+$/
+    : /^https:\/\/[^ "]+$/;
   const regex = new RegExp(expression);
 
   return regex.test(url);

--- a/utils/commons/checkUrl.ts
+++ b/utils/commons/checkUrl.ts
@@ -1,6 +1,6 @@
 // url 유효성 검사 함수
 const checkUrl = (url: string): boolean => {
-  const expression = /^(ftp|http|https):\/\/[^ "]+$/;
+  const expression = /^(ftp|http|https):\/\/github.com\/[^ "]+$/;
   const regex = new RegExp(expression);
 
   return regex.test(url);


### PR DESCRIPTION
## What is this PR? :mag:

- Post page에서 깃허브 주소를 입력할 때 깃허브 주소가 'https://github.com/'으로 시작되도록 유효성 검사를 추가하였습니다. 
정규표현식을 잘 알진 못해서 맞게 작성한 건지는 잘 모르겠습니다.. 의견 부탁드립니다

(+) 일반 url과 github url인 경우를 나누기 위해 파라미터를 추가하였습니다

## branch

- refac/ValidateGithub -> dev

## Changes :memo:

- 위의 내용과 동일합니다.

#348 by @nno3onn 
