### PR TITLE
fix(GNB): 알림 드랍다운 겹치는 문제 Z-index로 해결

### DIFF
--- a/Components/Common/PrimaryButton.tsx
+++ b/Components/Common/PrimaryButton.tsx
@@ -71,7 +71,7 @@ const PrimaryButtonContainer = styled.button<{
 
   /* "s" | "m": */
   width: ${({ size }) => (size === "m" ? `10rem` : `5.5rem`)};
-  height: ${({ size }) => (size === "m" ? "3.75rem" : "3rem")};
+  height: ${({ size }) => (size === "m" ? "3.5rem" : "3rem")};
 `;
 
 export default PrimaryButton;

--- a/Components/Detail/DetailTitle.tsx
+++ b/Components/Detail/DetailTitle.tsx
@@ -58,7 +58,7 @@ const DetailTitleBackgroundImage = styled(Image)`
 
 const DetailTitleHeader = styled.p`
   ${({ theme }) => theme.fonts.subtitle18En};
-  color: ${(props) => props.theme.colors.gray3};
+  color: ${(props) => props.theme.colors.white};
   z-index: 1;
 `;
 
@@ -72,7 +72,7 @@ const DetailTitleText = styled.div`
   }
   h3 {
     ${({ theme }) => theme.fonts.subtitle18};
-    color: ${(props) => props.theme.colors.gray3};
+    color: ${(props) => props.theme.colors.white};
   }
   z-index: 1;
 `;

--- a/Components/Layouts/GNB.tsx
+++ b/Components/Layouts/GNB.tsx
@@ -193,6 +193,7 @@ const NotificationContainer = styled.div`
   position: absolute;
   top: 3.75rem;
   right: 2.5rem;
+  z-index: 2;
 `;
 
 const GNBContainer = styled.div`


### PR DESCRIPTION
![스크린샷 2023-03-08 오후 5 39 44](https://user-images.githubusercontent.com/84452145/223664317-aea2f8c2-d187-4f16-9242-1be94ef3d00b.png)

![스크린샷 2023-03-08 오후 5 57 37](https://user-images.githubusercontent.com/84452145/223668383-f9157c98-a728-4aed-961d-efb401e3ac60.png)

## What is this PR? :mag:

- 알림 드랍다운 겹치는 문제 Z-index로 해결
- Detail 텍스트 안보이는 문제도 겸사겸사

## branch

- feat/ -> dev

## Changes :memo:

-

(#361) by @arch-spatula 
