### PR TITLE
fix: detail에서 깃,배포 링크 안보이는 에러

### DIFF
--- a/Components/Detail/DetailArticle.tsx
+++ b/Components/Detail/DetailArticle.tsx
@@ -38,6 +38,8 @@ const DetailArticle = () => {
     skills: ["Front-end", "Android"],
     tag: [""],
     members: [""],
+    githubUrl: "",
+    deployUrl: "",
   });
   const [content, setContent] = useState("");
   const [author, setAuthor] = useState("");
@@ -66,6 +68,8 @@ const DetailArticle = () => {
             skills: data.skills,
             tag: data.tag,
             members: data.members,
+            githubUrl: data.github_url,
+            deployUrl: data.deployed_url,
           });
           setContent(data.content);
           setAuthor(data.user_id);

--- a/Components/Detail/DetailSide/DetailSide.tsx
+++ b/Components/Detail/DetailSide/DetailSide.tsx
@@ -10,6 +10,8 @@ interface DetailSideProps {
   skills: string[];
   members: string[];
   authorInfo: UserProfileType | null | undefined;
+  githubUrl: string | undefined;
+  deployUrl: string | undefined;
 }
 
 const DetailSide = ({
@@ -19,6 +21,8 @@ const DetailSide = ({
   skills,
   members,
   authorInfo,
+  githubUrl,
+  deployUrl,
 }: DetailSideProps) => {
   return (
     <SideContainer>
@@ -27,6 +31,8 @@ const DetailSide = ({
         progressDate={progressDate}
         tag={tag}
         skills={skills}
+        githubUrl={githubUrl}
+        deployUrl={deployUrl}
       />
       <DetailSidePeople
         authorInfo={authorInfo}

--- a/Components/Detail/DetailSide/DetailSideProject.tsx
+++ b/Components/Detail/DetailSide/DetailSideProject.tsx
@@ -17,8 +17,8 @@ const DetailSideProject = ({
   progressDate,
   skills,
   tag,
-  githubUrl = "",
-  deployUrl = "",
+  githubUrl,
+  deployUrl,
 }: DetailSideProjectProps) => {
   const router = useRouter();
   return (


### PR DESCRIPTION
#360

## What is this PR? :mag:

- detail에서 깃,배포 링크 안보이는 에러 해결했습니다

## branch

- fix:/detail-page-ProjectLink -> dev

## Changes :memo:

- props로 제대로 전달이 안돼있어서 발생한 에러입니다. 

(#360 ) by @yunjunhojj 
